### PR TITLE
解决某些情况下 DNS 不能解析和兼容 ipv6 的问题

### DIFF
--- a/bypass-lan-and-china.pac
+++ b/bypass-lan-and-china.pac
@@ -27,6 +27,9 @@ var proxy = "__PROXY__";
 var direct = "DIRECT";
 
 function FindProxyForURL(url, host) {
+  if (!isResolvable(host)) {
+      return proxy;
+  }
   var remote = dnsResolve(host);
   if (belongsToSubnet(remote, WHITELIST)) {
       return direct;

--- a/code.js
+++ b/code.js
@@ -32,6 +32,9 @@ function isLan(host) {
 }
 
 function FindProxyForURL(url, host) {
+  if (!isResolvable(host)) {
+      return proxy;
+  }
   var remote = dnsResolve(host);
   if (isLan(remote) || isChina(remote)) {
       return "DIRECT";


### PR DESCRIPTION
在使用过程中发现有时会出现DNS解析失败的问题, 浏览器报 ERR_NAME_NOT_RESOLVED 错误
修改了一下 pac 的部分, 同时可以兼容 ipv6 的情况, fix #1 